### PR TITLE
Add AJAX button Logseq plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,23 @@
+# Logseq AJAX Button Plugin
+
+This plugin adds a custom macro that renders a button. When clicked, the button sends a POST request to a server. The message and server URL are configured directly in your Markdown using the macro arguments.
+
+## Usage
+
+Write a macro in any block:
+
+```
+{{renderer :ajax-button, url:"https://example.com/api", message:"Hello", label:"Send"}}
+```
+
+Arguments:
+
+- `url` – Endpoint that receives the POST request.
+- `message` – Message to send as JSON body `{ "message": "..." }`.
+- `label` – Optional text shown on the button (defaults to "Send").
+
+When clicked, the plugin sends a `POST` request with the JSON body including your message.
+
+## Development
+
+There is no build step. The plugin entry point is `index.js`. Run `npm test` to verify basic setup (no tests are defined).

--- a/index.js
+++ b/index.js
@@ -1,0 +1,50 @@
+function parseProps(str) {
+  const result = {};
+  if (!str) return result;
+  const parts = str.split(/,(?![^\"]*\")/);
+  for (let part of parts) {
+    part = part.trim();
+    const idx = part.indexOf(":");
+    if (idx === -1) continue;
+    const key = part.slice(0, idx).trim();
+    let value = part.slice(idx + 1).trim();
+    if (value.startsWith("\"") && value.endsWith("\"")) {
+      value = value.slice(1, -1);
+    }
+    result[key] = value;
+  }
+  return result;
+}
+
+function createButton(props, slot) {
+  const label = props.label || "Send";
+  const url = props.url;
+  const message = props.message || "";
+  if (!url) return;
+  const btn = document.createElement("button");
+  btn.textContent = label;
+  btn.addEventListener("click", async () => {
+    try {
+      await fetch(url, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ message })
+      });
+      logseq.UI.showMsg(`Sent: ${message}`);
+    } catch (e) {
+      logseq.UI.showMsg(`Error: ${e.message}`);
+    }
+  });
+  logseq.provideUI({ key: slot, slot, template: btn.outerHTML });
+}
+
+function main() {
+  logseq.App.onMacroRendererSlotted(({ slot, payload }) => {
+    const [type, args] = payload.arguments;
+    if (type !== "ajax-button") return;
+    const props = parseProps(args);
+    createButton(props, slot);
+  });
+}
+
+logseq.ready(main).catch(console.error);

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,8 @@
+{
+  "id": "logseq-ajax-button",
+  "name": "AJAX Button",
+  "description": "Add clickable buttons that send AJAX requests.",
+  "author": "Codex",
+  "version": "0.0.1",
+  "main": "index.js"
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "logseq-ajax-button",
+  "version": "0.0.1",
+  "description": "Logseq plugin to add clickable buttons that send AJAX requests.",
+  "main": "index.js",
+  "scripts": {
+    "build": "echo 'Nothing to build'",
+    "test": "echo 'No tests specified' && exit 0"
+  },
+  "keywords": ["logseq", "plugin", "ajax"],
+  "author": "Codex",
+  "license": "MIT",
+  "type": "commonjs"
+}


### PR DESCRIPTION
## Summary
- set up minimal Node project
- implement basic logseq plugin to render AJAX buttons
- document how to use the plugin

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683e8fc72a4c832887a1809adfc6e398